### PR TITLE
feat: set AzureWebJobsSecretStorageType to files

### DIFF
--- a/Dao.AI.BreakPoint.AppHost/AppHost.cs
+++ b/Dao.AI.BreakPoint.AppHost/AppHost.cs
@@ -1,4 +1,3 @@
-using Aspire.Hosting.Azure.Storage;
 using Azure.Provisioning.Storage;
 
 var builder = DistributedApplication.CreateBuilder(args);
@@ -61,7 +60,8 @@ var analyzerFunction = builder
         storage,
         StorageBuiltInRole.StorageBlobDataContributor,
         StorageBuiltInRole.StorageBlobDataReader
-    );
+    )
+    .WithEnvironment("AzureWebJobsSecretStorageType", "files");
 
 // Frontend App
 var breakPointApp = builder


### PR DESCRIPTION
Add environment variable to store Azure Functions secrets in files instead of Azure Storage for analyzerFunction.