### PR TITLE
feat: improve domain/cert param handling in deploy

### DIFF
--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -46,16 +46,22 @@ jobs:
 
 
       - name: Provision Infrastructure
-        run: azd provision --no-prompt
+        run: |
+          azd provision --no-prompt `
+            --set breakpointCustomDomain="${{ vars.BREAKPOINT_CUSTOM_DOMAIN }}" `
+            --set breakpointCertificateName="${{ vars.BREAKPOINT_CERTIFICATE_NAME }}" `
+            --set apiCustomDomain="${{ vars.API_CUSTOM_DOMAIN }}" `
+            --set apiCertificateName="${{ vars.API_CERTIFICATE_NAME }}"
         env:
           AZURE_POSTGRES_PASSWORD: ${{ secrets.AZURE_POSTGRES_PASSWORD }}
-          breakpointCustomDomain: ${{ vars.BREAKPOINT_CUSTOM_DOMAIN }}
-          breakpointCertificateName: ${{ vars.BREAKPOINT_CERTIFICATE_NAME }}
-          apiCustomDomain: ${{ vars.API_CUSTOM_DOMAIN }}
-          apiCertificateName: ${{ vars.API_CERTIFICATE_NAME }}
 
       - name: Deploy Application
-        run: azd deploy --no-prompt
+        run: |
+          azd deploy --no-prompt `
+            --set breakpointCustomDomain="${{ vars.BREAKPOINT_CUSTOM_DOMAIN }}" `
+            --set breakpointCertificateName="${{ vars.BREAKPOINT_CERTIFICATE_NAME }}" `
+            --set apiCustomDomain="${{ vars.API_CUSTOM_DOMAIN }}" `
+            --set apiCertificateName="${{ vars.API_CERTIFICATE_NAME }}"
         env:
           AZURE_POSTGRES_PASSWORD: ${{ secrets.AZURE_POSTGRES_PASSWORD }}
         

--- a/Dao.AI.BreakPoint.AppHost/AppHost.cs
+++ b/Dao.AI.BreakPoint.AppHost/AppHost.cs
@@ -1,10 +1,11 @@
 using Azure.Provisioning.Storage;
 
 var builder = DistributedApplication.CreateBuilder(args);
-var breakpointCustomDomain = builder.AddParameter("breakpointCustomDomain", secret: false);
-var breakpointCertificateName = builder.AddParameter("breakpointCertificateName", secret: false);
-var apiCustomDomain = builder.AddParameter("apiCustomDomain", secret: false);
-var apiCertificateName = builder.AddParameter("apiCertificateName", secret: false);
+// these values are dummy, only used when deployed
+var breakpointCustomDomain = builder.AddParameter("breakpointCustomDomain", secret: false, value: "dev.breakpoint.com");
+var breakpointCertificateName = builder.AddParameter("breakpointCertificateName", secret: false, value: "devcert");
+var apiCustomDomain = builder.AddParameter("apiCustomDomain", secret: false, value: "dev.breakpointapi.com");
+var apiCertificateName = builder.AddParameter("apiCertificateName", secret: false, value: "devapicert");
 
 // Add Azure Container App Environment to enable role assignments
 builder.AddAzureContainerAppEnvironment("breakpointenv");


### PR DESCRIPTION
Pass custom domain and certificate params via --set in azd steps. Set dummy defaults for local dev in AppHost.cs. Removes env vars.

closes #40