### PR TITLE
feat(ci): automate custom domain binding post-deploy

### DIFF
--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -13,7 +13,6 @@ permissions:
   id-token: write
   contents: read
 
-
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -26,8 +25,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Install azd
         uses: Azure/setup-azd@v2
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
@@ -44,22 +45,14 @@ jobs:
             --tenant-id "$Env:AZURE_TENANT_ID"
         shell: pwsh
 
-
       - name: Provision Infrastructure
         run: azd provision --no-prompt
-        env:
-          AZURE_POSTGRES_PASSWORD: ${{ secrets.AZURE_POSTGRES_PASSWORD }}
-          breakpointCustomDomain: ${{ vars.BREAKPOINT_CUSTOM_DOMAIN }}
-          breakpointCertificateName: ${{ vars.BREAKPOINT_CERTIFICATE_NAME }}
-          apiCustomDomain: ${{ vars.API_CUSTOM_DOMAIN }}
-          apiCertificateName: ${{ vars.API_CERTIFICATE_NAME }}
 
       - name: Deploy Application
         run: azd deploy --no-prompt
         env:
-          AZURE_POSTGRES_PASSWORD: ${{ secrets.AZURE_POSTGRES_PASSWORD }}
-          breakpointCustomDomain: ${{ vars.BREAKPOINT_CUSTOM_DOMAIN }}
-          breakpointCertificateName: ${{ vars.BREAKPOINT_CERTIFICATE_NAME }}
-          apiCustomDomain: ${{ vars.API_CUSTOM_DOMAIN }}
-          apiCertificateName: ${{ vars.API_CERTIFICATE_NAME }}
+          BREAKPOINT_CUSTOM_DOMAIN: ${{ vars.BREAKPOINT_CUSTOM_DOMAIN }}
+          BREAKPOINT_CERTIFICATE_NAME: ${{ vars.BREAKPOINT_CERTIFICATE_NAME }}
+          API_CUSTOM_DOMAIN: ${{ vars.API_CUSTOM_DOMAIN }}
+          API_CERTIFICATE_NAME: ${{ vars.API_CERTIFICATE_NAME }}
         

--- a/Dao.AI.BreakPoint.AppHost/AppHost.cs
+++ b/Dao.AI.BreakPoint.AppHost/AppHost.cs
@@ -1,11 +1,6 @@
 using Azure.Provisioning.Storage;
 
 var builder = DistributedApplication.CreateBuilder(args);
-// these values are dummy, only used when deployed
-var breakpointCustomDomain = builder.AddParameter("breakpointCustomDomain", secret: false, value: "dev.breakpoint.com");
-var breakpointCertificateName = builder.AddParameter("breakpointCertificateName", secret: false, value: "devcert");
-var apiCustomDomain = builder.AddParameter("apiCustomDomain", secret: false, value: "dev.breakpointapi.com");
-var apiCertificateName = builder.AddParameter("apiCertificateName", secret: false, value: "devapicert");
 
 // Add Azure Container App Environment to enable role assignments
 builder.AddAzureContainerAppEnvironment("breakpointenv");

--- a/azure.yaml
+++ b/azure.yaml
@@ -6,3 +6,8 @@ services:
     language: dotnet
     project: ./Dao.AI.BreakPoint.AppHost/Dao.AI.BreakPoint.AppHost.csproj
     host: containerapp
+
+hooks:
+  postdeploy:
+    shell: pwsh
+    run: ./infra/hooks/postdeploy.ps1

--- a/infra/hooks/postdeploy.ps1
+++ b/infra/hooks/postdeploy.ps1
@@ -1,0 +1,29 @@
+#!/usr/bin/env pwsh
+# Post-deploy hook to configure custom domains on Container Apps
+# Custom domains get removed when container apps are updated, so we re-bind them after each deploy
+
+$resourceGroup = "rg-$env:AZURE_ENV_NAME"
+
+# Frontend app custom domain
+if ($env:BREAKPOINT_CUSTOM_DOMAIN -and $env:BREAKPOINT_CERTIFICATE_NAME) {
+    Write-Host "Binding custom domain '$env:BREAKPOINT_CUSTOM_DOMAIN' to frontend app..."
+    az containerapp hostname bind `
+        --hostname $env:BREAKPOINT_CUSTOM_DOMAIN `
+        --resource-group $resourceGroup `
+        --name "breakpoint" `
+        --certificate $env:BREAKPOINT_CERTIFICATE_NAME `
+        --validation-method CNAME
+}
+
+# API custom domain
+if ($env:API_CUSTOM_DOMAIN -and $env:API_CERTIFICATE_NAME) {
+    Write-Host "Binding custom domain '$env:API_CUSTOM_DOMAIN' to API..."
+    az containerapp hostname bind `
+        --hostname $env:API_CUSTOM_DOMAIN `
+        --resource-group $resourceGroup `
+        --name "breakpointapi" `
+        --certificate $env:API_CERTIFICATE_NAME `
+        --validation-method CNAME
+}
+
+Write-Host "Custom domain configuration complete."


### PR DESCRIPTION
Refactor env var naming for custom domains/certs to uppercase. Remove azd provision step from pipeline; use only azd deploy. Move custom domain/cert config out of AppHost.cs.
Add postdeploy PowerShell hook to re-bind domains after deploy.